### PR TITLE
Add a shell for use by our purescript packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,12 +47,32 @@
       flake // {
         defaultPackage = flake.packages."purenix:exe:purenix";
 
+        # This shell is for hacking on purenix itself.  You get GHC with a
+        # suitable package database, as well as all the development tools as
+        # defined above.  You also get purs and spago that can be used for
+        # testing out purenix.
         devShell = flake.devShell.overrideAttrs (oldAttrs: {
           nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [
             pkgs.hsPkgs.hsPkgs.purescript.components.exes.purs
             pkgs.spago
           ];
         });
+
+        # This is a shell that contains purenix, purs, and spago.  It will
+        # mainly be used by the flake.nix for all our PureScript packages.
+        # It can also be used by users who just want to play around with
+        # purenix, but not hack on it.
+        devShells.use-purenix =
+          pkgs.stdenv.mkDerivation {
+            name = "use-purenix-shell";
+            nativeBuildInputs = [
+              pkgs.hsPkgs.hsPkgs.purescript.components.exes.purs
+              pkgs.spago
+              self.defaultPackage.${system}
+            ];
+            dontUnpack = true;
+            installPhase = "touch $out";
+          };
       }
     );
 }


### PR DESCRIPTION
This PR adds a separate devShell that is mainly for use by the `flake.nix` in our PureScript packages.

This new devShell just contains `purenix`, `purs`, and `spago`.  It doesn't contain GHC or any Haskell tools.