### PR TITLE
Don't output "Converting <file>..."

### DIFF
--- a/src/PureNix/Main.hs
+++ b/src/PureNix/Main.hs
@@ -27,7 +27,6 @@ defaultMain = do
   forM_ moduleDirs $ \rel -> do
     let dir = moduleRoot </> rel
     let file = dir </> "corefn.json"
-    putStrLn $ "Converting " <> file <> "..."
     value <- Aeson.eitherDecodeFileStrict file >>= either Sys.die pure
     (_version, module') <- either Sys.die pure $ parseEither moduleFromJSON value
     (nix, ModuleInfo usesFFI interpolations) <- either (Sys.die . T.unpack) pure $ convert module'


### PR DESCRIPTION
Fixes #19 

I imagine at some point we might allow a `--verbose` flag, or something like that, but for now I think Dennis is right in that it 
 unnecessarily pollutes the output.