### PR TITLE
Simplify PSString handling

### DIFF
--- a/src/PureNix/Convert.hs
+++ b/src/PureNix/Convert.hs
@@ -24,7 +24,7 @@ import PureNix.Prelude
 type Convert =
   ReaderT
     (FilePath, P.ModuleName, SourceSpan)
-    (StateT ModuleInfo (Either Text))
+    (State ModuleInfo)
 
 data ModuleInfo = ModuleInfo
   { usesFFI :: Bool,
@@ -39,9 +39,9 @@ instance Monoid ModuleInfo where mempty = ModuleInfo False mempty
 tell :: ModuleInfo -> Convert ()
 tell m = modify (mappend m)
 
-convert :: Module Ann -> Either Text (N.Expr, ModuleInfo)
+convert :: Module Ann -> (N.Expr, ModuleInfo)
 convert (Module spn _comments name path imports exports reexports foreign' decls) =
-  flip runStateT mempty $
+  flip runState mempty $
     flip runReaderT (path, name, spn) $
       module' name imports exports reexports foreign' decls
 

--- a/src/PureNix/Main.hs
+++ b/src/PureNix/Main.hs
@@ -6,7 +6,6 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (parseEither)
 import Data.Foldable (toList)
 import Data.List (intercalate)
-import qualified Data.Text as T
 import qualified Data.Text.Lazy.IO as TL
 import qualified Language.PureScript.CoreFn as P
 import Language.PureScript.CoreFn.FromJSON (moduleFromJSON)
@@ -29,7 +28,7 @@ defaultMain = do
     let file = dir </> "corefn.json"
     value <- Aeson.eitherDecodeFileStrict file >>= either Sys.die pure
     (_version, module') <- either Sys.die pure $ parseEither moduleFromJSON value
-    (nix, ModuleInfo usesFFI interpolations) <- either (Sys.die . T.unpack) pure $ convert module'
+    let (nix, ModuleInfo usesFFI interpolations) = convert module'
     TL.writeFile (dir </> "default.nix") (renderExpr nix)
     let modulePath = P.modulePath module'
         foreignSrc = workdir </> FP.replaceExtension modulePath "nix"


### PR DESCRIPTION
We use `decodeString` to convert from PSString to Text.
`decodeString`, and the rest of PS's string conversion functions, take extra care to make sure they don't output invalid unicode code points. That's nice, but it is also the only place where we ever throw an error during conversion, and I don't think the cost of the error handling logic is worth the benefit of handling unicode edge cases.
I think it's fine to just rely on Haskell's native conversion functions instead.
Maybe when we have a test suite we can start to catalogue the exact edge cases and how we want to handle them, maybe we just throw warnings.