### PR TITLE
Add back flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1636886446,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }


### PR DESCRIPTION
> I removed use of flake-utils since it it not used in the flake templates: https://github.com/NixOS/templates.
>
> It also is one less flake input we have to keep around.
>
> I don't particularly feel strongly about this though, so I'd be fine with adding it back in.

I like flake-utils quite a bit; it's lightweight, stable, common enough to be idiomatic, and cleans up flakes things quite a bit