### PR TITLE
add quick-start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Simply set `backend = "purenix"`, make sure `purenix` is available in the `PATH`
 When you run `purenix`, manually or through Spago, it will look for the Purescript output directory `./output` in the current working directory.
 It then traverses this directory structure, looks for Purescript's intermediate `corefn.json` files, transpiles the `corefn.json` files to the equivalent Nix code, and writes the output Nix code to `default.nix`.
 
-See [this post](https://discourse.nixos.org/t/purenix-nix-backend-for-purescript/15756/3) on the NixOS Discourse for more in-depth instructions.
-
+See the [Getting Started Guide](./docs/quick-start.md) for more in-depth instructions.
 
 ## Code sample
 
@@ -85,7 +84,7 @@ in
 
 There are a couple things to notice here:
 
-- PureScript built-in types like `String`, `Int`, objects, and lists are converted to their corresponding Nix types, as in `greeting`.
+- PureScript built-in types like `String`, `Int`, records, and lists are converted to their corresponding Nix types, as in `greeting`.
 - Data constructors from sum types are available to easily work with in the output Nix file, like `Just` and `Nothing`, although you might want to define named field accessors.
 - Foreign imports are straightforward to define and use, like in `add` and `foo`. The FFI file gets copied into the module's output directory as `foreign.nix`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+
+# Documentation for PureNix
+
+This directory contains documentation for PureNix.
+
+Here is the contents of each document:
+
+- [`./quick-start.md`](./quick-start.md)
+
+    A quick-start guide for getting started with using PureNix.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,10 +5,6 @@ Here's a quick-start guide for seting up a PureNix project.
 If something is unclear, you can always take a look at some of our libraries to see exactly how they are packaged, and copy what they do.
 For instance, [`purescript-foldable-traversable`](https://github.com/purenix-org/purescript-foldable-traversable) or [`purescript-maybe`](https://github.com/purenix-org/purescript-maybe).
 
-Currently, we only have a [temporary package set](https://github.com/purenix-org/temp-package-set).
-This post will explain how to get started with using it.
-There is an [open issue](https://github.com/purenix-org/purenix/issues/36) about creating an actual package set.
-
 ## Creating a development shell
 
 The PureNix flake exposes a development shell with tools like [PureScript](https://github.com/purescript/purescript), [Spago](https://github.com/purescript/spago), and PureNix.
@@ -50,15 +46,13 @@ This is pointing to the official PureScript package set, but you'll need to chan
 
 ```dhall
 let upstream =
-      https://raw.githubusercontent.com/purenix-org/temp-package-set/cf5984ed43685ced920cc2c5317d6eb17851bba3/packages.dhall
+      https://raw.githubusercontent.com/purenix-org/temp-package-set/4161ef177916d7dbf454ea7bcacd1698544d89c7/packages.dhall
 
 in  upstream
 ```
 
-You may want to use a more recent commit, but be warned that not all packages work in all commits.
-The package set is currently a work-in-progress.
-Please open an issue on <https://github.com/purenix-org/temp-package-set> if something is not working or you'd like to add one of your own packages.
-See <https://github.com/purescript/package-sets> for what a proper PureScript package set looks like.
+You may want to change the commit to be the [most recent commit from `temp-package-set`](https://github.com/purenix-org/temp-package-set/commits/main).
+See the section at the bottom of this document for more information about package sets.
 
 (Note that `spago` will automatically add the `sha256:XXX` integrity check the first time you run `spago build`.)
 
@@ -161,10 +155,32 @@ A simple `flake.nix` may look like the following:
 
 With this in place, you can enter the dev shell just by running `nix develop`.
 
+## A Note about Package Sets
+
+A PureScript package set is a set of PureScript packages that are known to all compile and be useable together.
+PureScript package sets are very similar to Haskell [Stackage](https://www.stackage.org/) resolvers.
+
+The main [PureScript Package Sets repo](https://github.com/purescript/package-sets) is for the JavaScript backend.
+All the packages in this package set are meant to compile to JavaScript code.
+The PureScript Package Sets repo has a workflow and CI actions that make it easy for users to add new packages to the package set, upgrade existing packages, and make new releases of the package set itself.
+
+In order to use a package set when compiling with PureNix, you need to specify a PureNix-compatible package set.
+Currently, we only have a [temporary package set](https://github.com/purenix-org/temp-package-set) for PureNix.
+This package set pins all packages to their `master` branch.
+There are no workflows or CI actions for adding packages, upgrading existing packages, etc.
+This is sufficient for getting started with PureNix, but not ideal for large-scale, serious use of PureNix.
+There is an [open issue](https://github.com/purenix-org/purenix/issues/36) about creating an actual package set if you'd like to help with getting this off the ground.
+Please open an issue or PR on <https://github.com/purenix-org/temp-package-set> if something is not working or you'd like to add one of your own packages.
+
+You can find more info about PureScript package sets in the following places:
+
+- The [PureScript Package Sets repo](https://github.com/purescript/package-sets) for the JavaScript backend
+- The [Spago README](https://github.com/purescript/spago)
+- The [PureScript Registry README](https://github.com/purescript/registry/) (which is supposed to be the eventual successor to PureScript package sets)
+
 ## Problems / Questions / PRs
 
-Feel free to open an issue or send a PR on
-<https://github.com/purenix-org/purenix>.
+Feel free to open an issue or send a PR on <https://github.com/purenix-org/purenix>.
 
 The PureNix compiler is currently very usable, but the surrounding package set still needs some work.
 We'd love to get more people to help out with improving both PureNix and the surrounding ecosystem!

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,188 @@
+# Quick Start
+
+Here's a quick-start guide for playing around with PureNix.
+
+In general, I recommend you take a look at some of our libraries to see exactly
+how they are packaged, and copy what they do.  For instance,
+[`purescript-foldable-traversable`](https://github.com/purenix-org/purescript-foldable-traversable)
+or [`purescript-maybe`](https://github.com/purenix-org/purescript-maybe).
+
+Currently, we only have a
+[temporary package set](https://github.com/purenix-org/temp-package-set).  This
+post will explain how to get started with using it.  There is an
+[open issue](https://github.com/purenix-org/purenix/issues/36) about creating an
+actual package set.
+
+## Creating a development shell
+
+The PureNix flake exposes a development shell with tools like
+[PureScript](https://github.com/purescript/purescript),
+[Spago](https://github.com/purescript/spago), and PureNix.
+
+If you have flakes enabled, you can drop into the PureNix development shell
+with a command like this:
+
+```console
+$ nix develop github:purenix-org/purenix#use-purenix
+```
+
+From here, use `spago` to create your PureNix project:
+
+```console
+$ mkdir my-cool-project
+$ cd my-cool-project/
+$ spago init
+```
+
+This creates a few files.  You'll need to edit some of these files in order to
+work with PureNix.
+
+## Edit files
+
+This section explains exactly what you'll have to change from `spago`'s
+defaults in order to use PureNix.
+
+### `packages.dhall`
+
+This file defines the upstream package set you want to use.  It is somewhat
+similar to a `stack.yaml` file for Haskell packages.
+
+It currently looks like this:
+
+```dhall
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20211028/packages.dhall sha256:df6486e7fad6dbe724c4e2ee5eac65454843dce1f6e10dc35e0b1a8aa9720b26
+
+in  upstream
+```
+
+This is pointing to the official PureScript package set, but you'll need to
+change it point to the PureNix package set:
+
+```dhall
+let upstream =
+      https://raw.githubusercontent.com/purenix-org/temp-package-set/cf5984ed43685ced920cc2c5317d6eb17851bba3/packages.dhall
+
+in  upstream
+```
+
+You may want to use a more recent commit, but be warned that not all packages
+work in all commits.  The package set is currently a work-in-progress.  Please
+open an issue on <https://github.com/purenix-org/temp-package-set> if something
+is not working or you'd like to add one of your own packages.  See
+<https://github.com/purescript/package-sets> for what a proper PureScript package
+set looks like.
+
+(Note that `spago` will automatically add the `sha256:XXX` integrity check the
+first time you run `spago build`.)
+
+### `spago.dhall`
+
+This file defines your current package.  It is similar to a `.cabal` file for
+Haskell projects, or a `Cargo.toml` file for Rust projects.
+
+It currently looks like the following:
+
+```dhall
+{ name = "my-project"
+, dependencies = [ "console", "effect", "prelude", "psci-support" ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+}
+```
+
+You'll need to make the following changes:
+
+-   The temporary PureNix package set doesn't include some of the above
+    dependencies, so you need to remove them.  You can add other packages as
+    long as they are defined in the package set.
+-   There isn't any testing support in PureNix yet, so remove the test sources.
+-   You need to specify that `spago` should use the `purenix` executable as the
+    backend.
+
+The new `spago.dhall` should look something like this:
+
+```dhall
+{ name = "my-project"
+, dependencies = [ "foldable-traversable", "maybe", "prelude" ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs" ]
+, backend = "purenix"
+}
+```
+
+### `src/Main.purs`
+
+Now you're ready to actually write some PureScript code.
+
+Edit the `src/Main.purs` file to look like this:
+
+```purescript
+module Main where
+
+import Prelude
+
+import Data.Foldable (foldr)
+import Data.Maybe (Maybe(..))
+
+myNames :: String
+myNames =
+  foldr (\name accum -> name <> " " <> accum) "" ["Eelco", "Jon", "Graham"]
+```
+
+## Building
+
+You can use `spago` to compile the code:
+
+```console
+$ spago build
+```
+
+This creates the directory `output/` with all the built code.  For instance,
+your `src/Main.purs` module is built as `output/Main/default.nix`.  I recommend
+you take a quick look at it.  The conversion between PureScript and Nix is
+relatively straight-forward (except for pattern matching and type class
+dictionaries).
+
+## Using the built Nix code
+
+You can use the built Nix code as you'd expect:
+
+```console
+$ nix repl
+nix-repl> main = import ./output/Main/default.nix
+nix-repl> main.myNames
+"Eelco Jon Graham "
+```
+
+## Setting up a `flake.nix`
+
+It may be convenient to create a `flake.nix` for your project.  This can make
+it easy to quickly jump into a dev shell.
+
+A simple `flake.nix` may look like the following:
+
+```nix
+{
+  description = "my-cool-project";
+
+  inputs.purenix.url = "github:purenix-org/purenix";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, flake-utils, purenix }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShell = purenix.devShells.${system}.use-purenix;
+    });
+}
+```
+
+With this in place, you can enter the dev shell just by running `nix develop`.
+
+## Problems / Questions / PRs
+
+Feel free to open an issue or send a PR on
+<https://github.com/purenix-org/purenix>.
+
+The PureNix compiler is currently very usable, but the surrounding package set
+still needs some work.  We'd love to get more people to help out with improving
+both PureNix and the surrounding ecosystem!

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -2,25 +2,17 @@
 
 Here's a quick-start guide for seting up a PureNix project.
 
-If something is unclear, you can always take a look at some of our libraries to see exactly
-how they are packaged, and copy what they do.  For instance,
-[`purescript-foldable-traversable`](https://github.com/purenix-org/purescript-foldable-traversable)
-or [`purescript-maybe`](https://github.com/purenix-org/purescript-maybe).
+If something is unclear, you can always take a look at some of our libraries to see exactly how they are packaged, and copy what they do.
+For instance, [`purescript-foldable-traversable`](https://github.com/purenix-org/purescript-foldable-traversable) or [`purescript-maybe`](https://github.com/purenix-org/purescript-maybe).
 
-Currently, we only have a
-[temporary package set](https://github.com/purenix-org/temp-package-set).  This
-post will explain how to get started with using it.  There is an
-[open issue](https://github.com/purenix-org/purenix/issues/36) about creating an
-actual package set.
+Currently, we only have a [temporary package set](https://github.com/purenix-org/temp-package-set).
+This post will explain how to get started with using it.
+There is an [open issue](https://github.com/purenix-org/purenix/issues/36) about creating an actual package set.
 
 ## Creating a development shell
 
-The PureNix flake exposes a development shell with tools like
-[PureScript](https://github.com/purescript/purescript),
-[Spago](https://github.com/purescript/spago), and PureNix.
-
-If you have flakes enabled, you can drop into the PureNix development shell
-with a command like this:
+The PureNix flake exposes a development shell with tools like [PureScript](https://github.com/purescript/purescript), [Spago](https://github.com/purescript/spago), and PureNix.
+If you have flakes enabled, you can drop into the PureNix development shell with a command like this:
 
 ```console
 $ nix develop github:purenix-org/purenix#use-purenix
@@ -34,18 +26,16 @@ $ cd my-cool-project/
 $ spago init
 ```
 
-This creates a template project.  You'll need to edit some of these files in order to
-work with PureNix.
+This creates a template project.  You'll need to edit some of these files in order to work with PureNix.
 
 ## Edit files
 
-This section explains exactly what you'll have to change from `spago`'s
-defaults in order to use PureNix.
+This section explains exactly what you'll have to change from `spago`'s defaults in order to use PureNix.
 
 ### `packages.dhall`
 
-This file defines the upstream package set you want to use.  It is somewhat
-similar to a `stack.yaml` file for Haskell packages.
+This file defines the upstream package set you want to use.
+It is somewhat similar to a `stack.yaml` file for Haskell packages.
 
 It currently looks like this:
 
@@ -56,8 +46,7 @@ let upstream =
 in  upstream
 ```
 
-This is pointing to the official PureScript package set, but you'll need to
-change it point to the PureNix package set:
+This is pointing to the official PureScript package set, but you'll need to change it point to the PureNix package set:
 
 ```dhall
 let upstream =
@@ -66,20 +55,17 @@ let upstream =
 in  upstream
 ```
 
-You may want to use a more recent commit, but be warned that not all packages
-work in all commits.  The package set is currently a work-in-progress.  Please
-open an issue on <https://github.com/purenix-org/temp-package-set> if something
-is not working or you'd like to add one of your own packages.  See
-<https://github.com/purescript/package-sets> for what a proper PureScript package
-set looks like.
+You may want to use a more recent commit, but be warned that not all packages work in all commits.
+The package set is currently a work-in-progress.
+Please open an issue on <https://github.com/purenix-org/temp-package-set> if something is not working or you'd like to add one of your own packages.
+See <https://github.com/purescript/package-sets> for what a proper PureScript package set looks like.
 
-(Note that `spago` will automatically add the `sha256:XXX` integrity check the
-first time you run `spago build`.)
+(Note that `spago` will automatically add the `sha256:XXX` integrity check the first time you run `spago build`.)
 
 ### `spago.dhall`
 
-This file defines your current package.  It is similar to a `.cabal` file for
-Haskell projects, or a `Cargo.toml` file for Rust projects.
+This file defines your current package.
+It is similar to a `.cabal` file for Haskell projects, or a `Cargo.toml` file for Rust projects.
 
 It currently looks like the following:
 
@@ -93,12 +79,10 @@ It currently looks like the following:
 
 You'll need to make the following changes:
 
--   The temporary PureNix package set doesn't include some of the above
-    dependencies, so you need to remove them.  You can add other packages as
-    long as they are defined in the package set.
+-   The temporary PureNix package set doesn't include some of the above dependencies, so you need to remove them.
+    You can add other packages as long as they are defined in the package set.
 -   There isn't any testing support in PureNix yet, so remove the test sources.
--   You need to specify that `spago` should use the `purenix` executable as the
-    backend.
+-   You need to specify that `spago` should use the `purenix` executable as the backend.
 
 The new `spago.dhall` should look something like this:
 
@@ -138,11 +122,10 @@ You can use `spago` to compile the code:
 $ spago build
 ```
 
-This creates the directory `output/` with all the built code.  For instance,
-your `src/Main.purs` module is built as `output/Main/default.nix`.  I recommend
-you take a quick look at it.  The conversion between PureScript and Nix is
-relatively straight-forward (except for pattern matching and type class
-dictionaries).
+This creates the directory `output/` with all the built code.
+For instance, your `src/Main.purs` module is built as `output/Main/default.nix`.
+I recommend you take a quick look at it.
+The conversion between PureScript and Nix is relatively straight-forward (except for pattern matching and type class dictionaries).
 
 ## Using the built Nix code
 
@@ -157,8 +140,8 @@ nix-repl> main.myNames
 
 ## Setting up a `flake.nix`
 
-It may be convenient to create a `flake.nix` for your project.  This can make
-it easy to quickly jump into a dev shell.
+It may be convenient to create a `flake.nix` for your project.
+This can make it easy to quickly jump into a dev shell.
 
 A simple `flake.nix` may look like the following:
 
@@ -183,6 +166,5 @@ With this in place, you can enter the dev shell just by running `nix develop`.
 Feel free to open an issue or send a PR on
 <https://github.com/purenix-org/purenix>.
 
-The PureNix compiler is currently very usable, but the surrounding package set
-still needs some work.  We'd love to get more people to help out with improving
-both PureNix and the surrounding ecosystem!
+The PureNix compiler is currently very usable, but the surrounding package set still needs some work.
+We'd love to get more people to help out with improving both PureNix and the surrounding ecosystem!

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,8 +1,8 @@
 # Quick Start
 
-Here's a quick-start guide for playing around with PureNix.
+Here's a quick-start guide for seting up a PureNix project.
 
-In general, I recommend you take a look at some of our libraries to see exactly
+If something is unclear, you can always take a look at some of our libraries to see exactly
 how they are packaged, and copy what they do.  For instance,
 [`purescript-foldable-traversable`](https://github.com/purenix-org/purescript-foldable-traversable)
 or [`purescript-maybe`](https://github.com/purenix-org/purescript-maybe).
@@ -34,7 +34,7 @@ $ cd my-cool-project/
 $ spago init
 ```
 
-This creates a few files.  You'll need to edit some of these files in order to
+This creates a template project.  You'll need to edit some of these files in order to
 work with PureNix.
 
 ## Edit files


### PR DESCRIPTION
This PR adds a quick-start guide.

The contents of this guide are taken from <https://discourse.nixos.org/t/purenix-nix-backend-for-purescript/15756/3>.

This is for https://github.com/cdepillabout/open-blog-posts/pull/2#discussion_r776315747.
