### PR TITLE
Add a MEMBERS.md describing guidelines for purenix-org

### DIFF
--- a/.github/MEMBERS.md
+++ b/.github/MEMBERS.md
@@ -1,0 +1,25 @@
+
+# PureNix Organization Members
+
+This document lays out guidelines for members of the [`purenix-org`](https://github.com/purenix-org) GitHub Organization.
+If you get added to `purenix-org`, take a look at this document.
+
+Here are the main guidelines:
+
+-   If you've gotten the commit bit in `purenix-org`, we fully trust you to use it to improve the PureNix ecosystem.
+    You don't necessarily need to get permission on making any big changes, including things like creating new repositories, or re-organizing existing libraries.
+    (Of course, creating an issue or opening a proof-of-concept PR to discuss things beforehand is always welcome!)
+
+-   We generally want changes to come in through PRs, not to be committed directly to the master branch.
+    If you haven't gotten any feedback to your PR in a week or so, feel free to re-ping the other maintainers, or just merge the PR in yourself.
+
+-   We appreciate documentation, especially comments in the code, or markdown files in the repo.
+    If neither of those make sense, then an explanation in an issue or PR is also helpful.
+
+-   We value moving things forward over excessive bike-shedding.
+    Changes that turn out to be bad can always be rolled back.
+    Since PureNix is a new ecosystem, it has a much higher risk of never attracting maintainers and users, rather than failing for bad decisions made by the maintainers.
+
+-   Please be proactive in giving out the commit bit to people who seem interested in improving the PureNix ecosystem.
+
+If PureNix ever becomes widely successful, we may have to make these guidelines a tad more conservative.

--- a/.github/MEMBERS.md
+++ b/.github/MEMBERS.md
@@ -1,25 +1,23 @@
-
 # PureNix Organization Members
 
 This document lays out guidelines for members of the [`purenix-org`](https://github.com/purenix-org) GitHub Organization.
-If you get added to `purenix-org`, take a look at this document.
+If you get added to `purenix-org`, please read through it.
 
-Here are the main guidelines:
+1. Since PureNix is a new ecosystem, not attracting users and contributors is much more dangerous than poor decision-making.
+   We value moving things forward over excessive bike-shedding.
+   Changes that turn out to be bad can always be rolled back.
 
--   If you've gotten the commit bit in `purenix-org`, we fully trust you to use it to improve the PureNix ecosystem.
-    You don't necessarily need to get permission on making any big changes, including things like creating new repositories, or re-organizing existing libraries.
-    (Of course, creating an issue or opening a proof-of-concept PR to discuss things beforehand is always welcome!)
+   There may come a time to make these guidelines more conservative, but that is certainly not now.
 
--   We generally want changes to come in through PRs, not to be committed directly to the master branch.
-    If you haven't gotten any feedback to your PR in a week or so, feel free to re-ping the other maintainers, or just merge the PR in yourself.
+2. As an `purenix-org` member, we fully trust your ability to improve the PureNix ecosystem.
+   You are free to change as little or as much as you see fit, including big changes like creating new repositories, or re-organizing existing libraries.
+   You don't necessarily need to ask for permission, but of course, creating an issue or opening a proof-of-concept PR to discuss things beforehand is always welcome!
 
--   We appreciate documentation, especially comments in the code, or markdown files in the repo.
-    If neither of those make sense, then an explanation in an issue or PR is also helpful.
+3. Please be proactive in giving out the commit bit to people who seem interested in improving the PureNix ecosystem.
+   If you do, please show them this page.
 
--   We value moving things forward over excessive bike-shedding.
-    Changes that turn out to be bad can always be rolled back.
-    Since PureNix is a new ecosystem, it has a much higher risk of never attracting maintainers and users, rather than failing for bad decisions made by the maintainers.
+4. We generally want changes to come in through PRs, not to be committed directly to the master branch.
+   If you haven't gotten any feedback to your PR in a week or so, feel free to re-ping the other maintainers, or just merge the PR in yourself.
 
--   Please be proactive in giving out the commit bit to people who seem interested in improving the PureNix ecosystem.
-
-If PureNix ever becomes widely successful, we may have to make these guidelines a tad more conservative.
+5. We appreciate documentation, ideally comments in the code, or alternatively markdown files in the repo.
+   If neither of those make sense, then an explanation in an issue or PR is also helpful.


### PR DESCRIPTION
This PR adds a `MEMBERS.md` file that basically says that people added to `purenix-org` are free to make any changes they deem helpful.  They don't necessarily have to wait for approval from the other maintainers.