### PR TITLE
Enhance use-purenix-shell

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -48,6 +48,7 @@ final: prev: {
       final.purescript
       final.ormolu
       final.spago
+      final.bashInteractive # see: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
     ];
   };
 
@@ -57,6 +58,11 @@ final: prev: {
       final.purenix
       final.purescript
       final.spago
+      final.dhall-lsp-server
+      final.nodePackages.purty
+      final.nodePackages.purescript-psa
+      final.nixpkgs-fmt
+      final.bashInteractive # See: https://discourse.nixos.org/t/interactive-bash-with-nix-develop-flake/15486
     ];
     dontUnpack = true;
     installPhase = "touch $out";


### PR DESCRIPTION
this PR

- adds some packages to the purenix shell that I think are useful when developing purenix code
  - [purescript-psa](https://github.com/natefaubion/purescript-psa): Useful for e.g. turning Warnings into errors. It's integrated into spago, if installed in your env
  - dhall-lsp-server: mainly useful to format dhall files
  - purty: Format purescript files
  - nixpkgs-fmt: Format nix files

- ~~adds `bashInteractive`: if this is not in the env, some terminals don't work properly. Eg. vscode's terminal when you launch the editor from within a "flake" nix shell.~~

- ~~Modifies `PS1` when entering the shell. Just adding a `purenix*` in front of the existing `PS1` seems to be the least intrusive solution to me.~~

- ~~does a little refactoring:~~
  - ~~use `mkShell` instead of `stdenv.mkDerivation`~~
  - ~~use a `with` statement to reduce repetition~~