### PR TITLE
Trigger CI on PRs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+  push:
 
 jobs:
 


### PR DESCRIPTION
This makes sure GitHub Actions are triggered when someone sends a PR.

I was wondering why #45 didn't trigger CI, but I think it is because we're not triggering CI on PRs.  This PR fixes it.

I think I had seen @thought2 make this same change to another repo, and I had assumed we were doing the same thing here in this PureNix repo.  But it looks like we weren't!  Hopefully this should all be good now.