### PR TITLE
PS 0.15 hotfixes

### DIFF
--- a/src/PureNix/Identifiers.hs
+++ b/src/PureNix/Identifiers.hs
@@ -60,7 +60,7 @@ identToText (PS.Ident t) = t
 -- This was relaxed in 0.14.2:
 -- https://github.com/purescript/purescript/pull/4096
 identToText (PS.GenIdent mvar n) = fromMaybe "__instance" mvar <> T.pack (show n)
-identToText PS.UnusedIdent = error "impossible"
+identToText PS.UnusedIdent = "_"
 identToText (PS.InternalIdent _) = error "impossible"
 
 -- | Make a Nix variable binder from a CoreFn binder.

--- a/src/PureNix/Main.hs
+++ b/src/PureNix/Main.hs
@@ -22,7 +22,7 @@ defaultMain :: IO ()
 defaultMain = do
   let workdir = "."
   let moduleRoot = workdir </> "output"
-  moduleDirs <- filter (/= "cache-db.json") <$> Dir.listDirectory moduleRoot
+  moduleDirs <- filter (not . FP.isExtensionOf "json") <$> Dir.listDirectory moduleRoot
   forM_ moduleDirs $ \rel -> do
     let dir = moduleRoot </> rel
     let file = dir </> "corefn.json"


### PR DESCRIPTION
Fixes #52 

Contains 2 hotfixes for PureScript 0.15 issues.

1. `UnusedIdent` isn't what I thought it was; it's just an underscore.

2. PS now generates more `json` files in the output directory than before, we should skip all of them.

There's still issues where spago complains about bounds on the package sets, and there's a ton of warnings that need to be addressed.