### PR TITLE
Update `quick-start.md`

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -46,9 +46,10 @@ This is pointing to the official PureScript package set, but you'll need to chan
 
 ```dhall
 let upstream =
-      https://raw.githubusercontent.com/purenix-org/temp-package-set/4161ef177916d7dbf454ea7bcacd1698544d89c7/packages.dhall
+      https://raw.githubusercontent.com/purenix-org/temp-package-set/a14eb4db17fa84ed4d41aee16f6a18018f23ec64/packages.dhall
 
 in  upstream
+  with metadata.version = "v0.15.4"
 ```
 
 You may want to change the commit to be the [most recent commit from `temp-package-set`](https://github.com/purenix-org/temp-package-set/commits/main).


### PR DESCRIPTION
```
% spago build
[info] Generating new hashes for the package set file so it will be cached.. (this might take some time) [error] Oh noes! It looks like the PureScript version installed on your system is not compatible with the package-set you're using.

installed `purs` version:    0.15.4
minimum package-set version: 0.14.3

There are a few ways to solve this:
- install a compatible `purs` version (i.e. in the same 'semver range' as the one in the package set)
- if the `purs` version is 'too new', you can try using `spago upgrade-set` to upgrade to the latest package set
- if you know what you're doing and you want to disable this check, you can override the `version` of the `metadata` package in the packages.dhall, e.g.:

  let upstream = <package-set url here> in  upstream with metadata.version = "v0.15.4"
```