### PR TITLE
chore: adjust to purescript 0.15.12 corefn changes

### DIFF
--- a/src/PureNix/Expr.hs
+++ b/src/PureNix/Expr.hs
@@ -47,7 +47,14 @@ data ExprF f
   | Path Text
   deriving stock (Functor, Foldable, Traversable, Show)
 
-data Op = Update | Equals | And
+-- | Nix binary operators
+data Op =
+  -- | nix @//@ operator (right-side keys overwrite left side attrset)
+  Update |
+  -- | nix @==@ operator (equality)
+  Equals |
+  -- | nix @&&@ operator (boolean @and@)
+  And
   deriving (Eq, Show)
 
 foldExpr :: (ExprF r -> r) -> Expr -> r


### PR DESCRIPTION
Some of the constructors changed shape, but that shouldn’t influence purenix very much.

This probably can’t be merged as-is, I just did the minimal changes necessary to get it to compile again.