### PR TITLE
Purescript 0.15.12

### DIFF
--- a/src/PureNix/Expr.hs
+++ b/src/PureNix/Expr.hs
@@ -47,7 +47,14 @@ data ExprF f
   | Path Text
   deriving stock (Functor, Foldable, Traversable, Show)
 
-data Op = Update | Equals | And
+-- | Nix binary operators
+data Op =
+  -- | nix @//@ operator (right-side keys overwrite left side attrset)
+  Update |
+  -- | nix @==@ operator (equality)
+  Equals |
+  -- | nix @&&@ operator (boolean @and@)
+  And
   deriving (Eq, Show)
 
 foldExpr :: (ExprF r -> r) -> Expr -> r


### PR DESCRIPTION
This is currently blocked on `cheapskate-0.1.1.2` being broken in nixpkgs. Also, we should probably drop the CPP backwards compatible stuff, and just try to stay compatible with the latest Purescript release.