### PR TITLE
Limit purescrip to <0.15.12

### DIFF
--- a/purenix.cabal
+++ b/purenix.cabal
@@ -51,7 +51,7 @@ library
     , microlens-platform
     , mtl
     , pretty-simple
-    , purescript          ^>=0.15
+    , purescript          >=0.15 && <0.15.12
     , text
 
 executable purenix


### PR DESCRIPTION
0.15.12 is broken (#61 ), this limits to 0.15.11 for now